### PR TITLE
Handle link references the same way as links

### DIFF
--- a/__tests__/__snapshots__/hreflang.spec.js.snap
+++ b/__tests__/__snapshots__/hreflang.spec.js.snap
@@ -2,6 +2,8 @@
 
 exports[`hreflang renders a link with a four digits lang 1`] = `"<p>I love <a href=\\"https://www.canada.ca/fr.html\\" hreflang=\\"fr_ca\\">Canada</a>!</p>"`;
 
+exports[`hreflang renders a link with a reference for URL 1`] = `"<p>Did you get this <a href=\\"https://example.com\\" hreflang=\\"fr\\">reference</a>?</p>"`;
+
 exports[`hreflang renders a link with a two digits lang 1`] = `"<p>I use this plugin on <a href=\\"https://tzi.fr\\" hreflang=\\"fr\\">my own website</a>, because I mix several languages on it!</p>"`;
 
 exports[`hreflang renders a link with an invalid lang format 1`] = `"<p>The <a href=\\"https://www.6play.fr/kaamelott-p_888\\">Kaamelott TV shows (Celtes)</a> is really fun.</p>"`;

--- a/__tests__/hreflang.spec.js
+++ b/__tests__/hreflang.spec.js
@@ -38,4 +38,14 @@ describe("hreflang", function() {
 
     expect(contents).toMatchSnapshot();
   });
+
+  it("renders a link with a reference for URL", () => {
+    const {contents} = render(dedent`
+      Did you get this [reference (fr)][reference]?
+
+      [reference]: https://example.com
+    `);
+
+    expect(contents).toMatchSnapshot();
+  });
 });

--- a/dist/hreflang.js
+++ b/dist/hreflang.js
@@ -6,11 +6,11 @@ var _unistUtilSelect2 = _interopRequireDefault(_unistUtilSelect);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var pattern = new RegExp(" \\(([a-z]{2}(_[a-z]{2})?)\\)$", "gi");
+var pattern = new RegExp(" \\(([a-z]{2}(_[a-z]{2}|))\\)$", "i");
 
 function plugin() {
   return function transformer(ast) {
-    (0, _unistUtilSelect2.default)(ast, "link").forEach(function (node) {
+    (0, _unistUtilSelect2.default)(ast, "link,linkReference").forEach(function (node) {
       if (!node.children) {
         return;
       }

--- a/src/hreflang.js
+++ b/src/hreflang.js
@@ -4,7 +4,7 @@ const pattern = new RegExp(" \\(([a-z]{2}(_[a-z]{2}|))\\)$", "i");
 
 function plugin() {
   return function transformer(ast) {
-    select(ast, "link").forEach(node => {
+    select(ast, "link,linkReference").forEach(node => {
       if (!node.children) {
         return;
       }


### PR DESCRIPTION
Link references `[references][url-identifier]` are actually parsed as `linkReference` nodes not `link`, so the selector needed to be updated for that.